### PR TITLE
Clean up error messages

### DIFF
--- a/qri/client.py
+++ b/qri/client.py
@@ -6,7 +6,7 @@ import json
 import os
 import re
 
-from .cmd_util import shell_exec
+from .cmd_util import shell_exec, QriClientError
 from . import dataset
 
 
@@ -15,7 +15,7 @@ def list():
   cmd = 'qri list --format json'
   result, err = shell_exec(cmd)
   if err:
-    raise RuntimeError(err)
+    raise QriClientError(err)
   datasets = dataset.DatasetList([dataset.Dataset(d) for d in json.loads(result)])
   datasets.sort(key=lambda d: d.human_ref())
   return datasets
@@ -26,7 +26,7 @@ def get(ref):
   cmd = 'qri get --format json %s' % ref
   result, err = shell_exec(cmd)
   if err:
-    raise RuntimeError(err)
+    raise QriClientError(err)
   d = dataset.Dataset(json.loads(result))
   return d
 
@@ -36,4 +36,6 @@ def add(ref):
   cmd = 'qri add %s' % ref
   print('Fetching from registry...')
   result, err = shell_exec(cmd)
+  if err:
+    raise QriClientError(err)
   return 'Added %s: %s' % (ref, result)

--- a/qri/cmd_util.py
+++ b/qri/cmd_util.py
@@ -13,6 +13,10 @@ def shell_exec(command, cwd=None):
   stdout, err = proc.communicate()
   return stdout, err
 
+class QriClientError(RuntimeError):
+    def __init__(self, err_string):
+        clean_err_string = strip_color(err_string.decode('utf-8'))
+        super(QriClientError, self).__init__(clean_err_string)
 
 def strip_color(colored_text):
   """ strips color characters to return plaintext for when the


### PR DESCRIPTION
Currently we getting errors that look like `RuntimeError: b'\x1b[31mreference not found\x1b[0m\n'`. I saw the `strip_color` function and figured it was for this.

Not sure if my new `QriClientError` type is the right way. Perhaps I could wrap it in a function instead and stick to `RuntimeError`.