### PR TITLE
Send a list of commands to qri CLI directly instead of using shlex

### DIFF
--- a/qri/client.py
+++ b/qri/client.py
@@ -42,7 +42,7 @@ def add(refstr):
 
 def sql(query):
     """sql query run against a dataset"""
-    cmd = f'qri sql --format "json" "{query}"'
+    cmd = ['qri', 'sql', '--format', 'json', query]
     result, err = shell_exec(cmd)
     if err:
         raise QriClientError(err)

--- a/qri/cmd_util.py
+++ b/qri/cmd_util.py
@@ -6,8 +6,12 @@ import sys
 
 def shell_exec(command, cwd=None):
     """execute commands and return stdout"""
+    if isinstance(command, list):
+        command_list = command
+    else:
+        command_list = shlex.split(command)
     try:
-        proc = Popen(shlex.split(command),
+        proc = Popen(command_list,
                      stdin=PIPE,
                      stdout=PIPE,
                      stderr=PIPE,


### PR DESCRIPTION
This is layered on top of #19. We should probably merge that first.

# Explanation

Right now, within the various client methods, qri-python is using `shlex` to parse command strings such as:

```
'qri get --format json %s' % ref
```

Where `ref` is a parameter to the given method. `shlex` splits this command string into a list of strings using shell escaping rules. Thus, the user is unwittingly supplying a substring to a shell command string. This is fine most of the time, but it ends up with some problems when there's funny business with spaces, quotes, and probably some other things. Sometimes this just causes the user to get confusing error messages, but sometimes it causes unexpected behavior. I came up with several examples below.

I argue that since we already know the list of arguments that we should be passing in, we should just directly pass in the list. _However_, perhaps there's some reason we are using `shlex` that I am unaware of.

The remainder of this description is just the example errors.

# Example Errors

NOTE: The "Before" sections are assuming #19 has been merged.

## Sneaking in Legitimate CLI Arguments

### Before:

```
> qri.get("body b5/world_bank_population")

...

AttributeError: 'list' object has no attribute 'get'
```

### After

```
> qri.get("body b5/world_bank_population")

...

QriClientError: "body b5/world_bank_population" is not a valid dataset reference: unexpected character at position 4: ' '
```

## Unclosed Quotation

### Before

```
> qri.get("b5/'world_bank_population")

...

ValueError: No closing quotation
```

### After

```
> qri.get("b5/'world_bank_population")

...

QriClientError: "b5/'world_bank_population" is not a valid dataset reference: did not find valid dataset name
```

## Closed Quotation

### Before

```
> qri.get("b5/'wor'ld_bank_population")

Dataset("b5/world_bank_population")
```

### After:

```
> qri.get("b5/'wor'ld_bank_population")
QriClientError: "b5/'wor'ld_bank_population" is not a valid dataset reference: did not find valid dataset name
```

## SQL String With Spaces

This issue doesn't show up as easily if you are quoting strings without spaces, due to a quirk of shell escaping I guess.

### Before

```
> qri.sql('SELECT wbp.year_2010 name from b5/world_bank_population as wbp where wbp.country_name="Cayman Islands"')

...

QriClientError: accepts 1 arg(s), received 2
```

The problem is that in this case we actually need to pass `"` as part of the command to `qri`, since it's part of the SQL query. We need to escape the `"` to get it from the command line into an argument to `qri`. In order to do that, we need a `\`, which itself needs to be escaped to get it into the Python string:

```
> qri.sql('SELECT wbp.year_2010 name from b5/world_bank_population as wbp where wbp.country_name=\\"Cayman Islands\\"')

    name
0  56672
```

I reckon this would be a confusing experience for the user of the library.

### After

No need to worry about shell parsing. The Python string gets passed directly as an argument to `qri`:

```
> qri.sql('SELECT wbp.year_2010 name from b5/world_bank_population as wbp where wbp.country_name="Cayman Islands"')

    name
0  56672
```