### PR TITLE
Proposal: Split into Dataset and DatasetListItem

### DIFF
--- a/qri/client.py
+++ b/qri/client.py
@@ -3,8 +3,6 @@
 """Client for interacting with qri repositories"""
 
 import json
-import os
-import re
 
 from .cmd_util import shell_exec, QriClientError
 from . import dataset
@@ -18,19 +16,14 @@ def list():
     if err:
         raise QriClientError(err)
     raw_data = json.loads(result)
-    datasets = dataset.DatasetList([dataset.Dataset(d) for d in raw_data])
+    datasets = dataset.DatasetList([dataset.DatasetListItem(d) for d in raw_data])
     datasets.sort(key=lambda d: d.human_ref())
     return datasets
 
 
 def get(ref):
     """get a dataset in the repository by reference"""
-    cmd = 'qri get --format json %s' % ref
-    result, err = shell_exec(cmd)
-    if err:
-        raise QriClientError(err)
-    d = dataset.Dataset(json.loads(result))
-    return d
+    return dataset.Dataset(loader.get(ref))
 
 
 def pull(ref):

--- a/qri/loader.py
+++ b/qri/loader.py
@@ -1,7 +1,8 @@
 import base64
 import io
+import json
 import pandas
-from .cmd_util import shell_exec
+from .cmd_util import shell_exec, QriClientError
 
 
 def load_body(username, dsname, structure):
@@ -47,3 +48,11 @@ def pd_type(t):
     elif t == 'bool':
         return 'bool'
     raise RuntimeError('Unknown type: "%s"' % t)
+
+
+def get(ref):
+    cmd = 'qri get --format json %s' % ref
+    result, err = shell_exec(cmd)
+    if err:
+        raise QriClientError(err)
+    return json.loads(result)

--- a/qri/version_info.py
+++ b/qri/version_info.py
@@ -4,6 +4,9 @@ from .util import set_fields
 class VersionInfo(object):
     def __init__(self, obj):
         set_fields(self, obj, ['bodySize', 'bodyRows', 'bodyFormat', 'numErrors', 'commitTime'])
+        # TODO(dustmop): Remove me after this typo is fixed in qri core
+        if 'bodyFromat' in obj:
+            self.body_format = obj.get('bodyFromat')
 
     def __repr__(self):
         return 'VersionInfo()'


### PR DESCRIPTION
My goal here is to deal with the fact that `Dataset` items returned from `qri.list()` doesn't have all of the fields (notably including `body`) that do `Dataset` items returned from `qri.get(...)`. The fundamental problem is that `qri list` just gives different data than `qri get...` (and not a strict subset, either; it has the `versionInfo` stuff). I have two approaches in two different PRs. This is one of them (the other is #23)

For this approach, I create a new class `DatasetListItem` that contains only the stuff returned from `qri list`. `DatasetList` now contains these instead of `Dataset`. It has a method `.get()` (no parameters) which calls `qri get...` and returns the `Dataset` object.