### PR TITLE
Proposal: Auto-populate missing fields from Dataset object

### DIFF
--- a/qri/version_info.py
+++ b/qri/version_info.py
@@ -1,9 +1,0 @@
-from .util import set_fields
-
-
-class VersionInfo(object):
-    def __init__(self, obj):
-        set_fields(self, obj, ['bodySize', 'bodyRows', 'bodyFormat', 'numErrors', 'commitTime'])
-
-    def __repr__(self):
-        return 'VersionInfo()'

--- a/tests/dataset_test.py
+++ b/tests/dataset_test.py
@@ -1,0 +1,141 @@
+from qri import dataset
+from qri import loader
+import mock_loader
+import unittest
+
+# TODO - move these to a better place?
+LIST_OBJ = {
+    'username': 'me',
+    'profileID': 'Qm.profileID',
+    'name': 'first_dataset',
+    'path': '/ipfs/Qm.path',
+    'bodySize': 1,
+    'bodyRows': 2,
+    'numErrors': 3,
+    'bodyFormat': 'json',
+    'commitTime': '2020-08-24T20:00:32.171549113Z',
+    'fsiPath': '/home/my_user/datasets/first_dataset'
+}
+
+GET_OBJ = {
+    "bodyPath": "/ipfs/Qm.bodyPath",
+    "commit": {
+        "author": {"id": "Qm.commit.author.id"},
+        "message": "commit.message",
+        "timestamp": "2020-01-02T03:04:05.124963898Z",
+    },
+    "meta": {
+        "description": "meta.description",
+        "keywords": ["meta.keyword1", "meta.keyword2"],
+    },
+    "name": "first_dataset",
+    "path": "/ipfs/Qm.path",
+    "peername": "me",
+    "previousPath": "/ipfs/Qm.previousPath",
+    "readme": {
+        "scriptBytes": "VEVTVCBSRUFETUUK",
+    },
+    "structure": {
+        "checksum": "Qm.structure.checksum",
+        "entries": 3,
+        "format": "csv",
+        "schema": {
+            "items": {
+                "items": [
+                    {"title": "field1", "type": "string"},
+                    {"title": "field2", "type": "integer"},
+                ],
+                "type": "array",
+            },
+            "type": "array",
+        },
+    },
+}
+
+
+class DatasetTests(unittest.TestCase):
+    def test_init_from_list(self):
+        loader.set_instance(mock_loader.DatasetMockLoader())
+        ds = dataset.Dataset(LIST_OBJ)
+        self.assertEqual(ds.username, 'me')
+        self.assertEqual(ds.name, 'first_dataset')
+        self.assertEqual(ds.profile_id, 'Qm.profileID')
+        self.assertEqual(ds.path, '/ipfs/Qm.path')
+        self.assertFalse(ds._is_populated)
+
+    def test_init_from_get(self):
+        loader.set_instance(mock_loader.DatasetMockLoader())
+        ds = dataset.Dataset(GET_OBJ)
+        self.assertEqual(ds.username, 'me')
+        self.assertEqual(ds.name, 'first_dataset')
+        self.assertEqual(ds.path, '/ipfs/Qm.path')
+
+        self.assertEqual(ds.body_path_value, "/ipfs/Qm.bodyPath")
+        self.assertEqual(ds.previous_path_value, "/ipfs/Qm.previousPath")
+
+        # Checking a subset of the possible fields for brevity
+
+        # TODO - should I test every field? I realized it would get pretty verbose but I can.
+        # I figured I'd test set_fields and move on.
+        # However if you want a super verbose and thorough comparison I can do that.
+        self.assertIsInstance(ds.commit_component, dataset.Commit)
+        self.assertEqual(ds.commit_component.author, {"id": "Qm.commit.author.id"})
+        self.assertEqual(ds.commit_component.message, "commit.message")
+        self.assertEqual(ds.commit_component.timestamp, "2020-01-02T03:04:05.124963898Z")
+
+        self.assertIsInstance(ds.meta_component, dataset.Meta)
+        self.assertEqual(ds.meta_component.description, 'meta.description')
+        self.assertEqual(ds.meta_component.keywords, ['meta.keyword1', 'meta.keyword2'])
+
+        self.assertIsInstance(ds.readme_component, dataset.Readme)
+        self.assertEqual(ds.readme_component.script.strip(), "TEST README")
+
+        self.assertIsInstance(ds.structure_component, dataset.Structure)
+        self.assertEqual(ds.structure_component.entries, 3)
+        self.assertEqual(ds.structure_component.format, 'csv')
+        self.assertEqual(ds.structure_component.schema, {
+            "items": {
+                "items": [
+                    {"title": "field1", "type": "string"},
+                    {"title": "field2", "type": "integer"},
+                ],
+                "type": "array"
+            },
+            "type": "array"
+        })
+
+        self.assertIsNone(ds.body_component)
+
+        self.assertTrue(ds._is_populated)
+
+    def test_populate(self):
+        loader.set_instance(mock_loader.DatasetMockLoader(get_responses={
+            'me/first_dataset': GET_OBJ
+        }))
+        ds = dataset.Dataset(LIST_OBJ)
+        self.assertFalse(ds._is_populated)
+        self.assertFalse(hasattr(ds, 'meta_component'))
+        ds.meta
+        self.assertTrue(ds._is_populated)
+        self.assertTrue(hasattr(ds, 'meta_component'))
+        self.assertEqual(ds.meta.description, 'meta.description')
+
+    def test_dont_populate_twice(self):
+        loader.set_instance(mock_loader.DatasetMockLoader())
+        ds = dataset.Dataset(GET_OBJ)
+        self.assertTrue(ds._is_populated)
+        self.assertTrue(hasattr(ds, 'meta_component'))
+        ds.meta # The mock loader should complain if it calls "get"
+
+    def test_body(self):
+        loader.set_instance(mock_loader.DatasetMockLoader(get_body_responses={
+            'me/first_dataset': 'dataframe standin'
+        }))
+        ds = dataset.Dataset(GET_OBJ)
+        self.assertIsNone(ds.body_component)
+        ds.body
+        self.assertEqual(ds.body_component, 'dataframe standin')
+
+
+if __name__ == '__main__':
+  unittest.main()

--- a/tests/dataset_test.py
+++ b/tests/dataset_test.py
@@ -3,12 +3,12 @@ from qri import loader
 import mock_loader
 import unittest
 
-# TODO - move these to a better place?
+
 LIST_OBJ = {
-    'username': 'me',
-    'profileID': 'Qm.profileID',
+    'username': 'peer',
+    'profileID': 'QmProfileID',
     'name': 'first_dataset',
-    'path': '/ipfs/Qm.path',
+    'path': '/ipfs/QmPath',
     'bodySize': 1,
     'bodyRows': 2,
     'numErrors': 3,
@@ -18,9 +18,9 @@ LIST_OBJ = {
 }
 
 GET_OBJ = {
-    "bodyPath": "/ipfs/Qm.bodyPath",
+    "bodyPath": "/ipfs/QmBodyPath",
     "commit": {
-        "author": {"id": "Qm.commit.author.id"},
+        "author": {"id": "QmCommitAuthorId"},
         "message": "commit.message",
         "timestamp": "2020-01-02T03:04:05.124963898Z",
     },
@@ -29,14 +29,14 @@ GET_OBJ = {
         "keywords": ["meta.keyword1", "meta.keyword2"],
     },
     "name": "first_dataset",
-    "path": "/ipfs/Qm.path",
-    "peername": "me",
-    "previousPath": "/ipfs/Qm.previousPath",
+    "path": "/ipfs/QmPath",
+    "peername": "peer",
+    "previousPath": "/ipfs/QmPreviousPath",
     "readme": {
         "scriptBytes": "VEVTVCBSRUFETUUK",
     },
     "structure": {
-        "checksum": "Qm.structure.checksum",
+        "checksum": "QmStructureChecksum",
         "entries": 3,
         "format": "csv",
         "schema": {
@@ -57,29 +57,26 @@ class DatasetTests(unittest.TestCase):
     def test_init_from_list(self):
         loader.set_instance(mock_loader.DatasetMockLoader())
         ds = dataset.Dataset(LIST_OBJ)
-        self.assertEqual(ds.username, 'me')
+        self.assertEqual(ds.username, 'peer')
         self.assertEqual(ds.name, 'first_dataset')
-        self.assertEqual(ds.profile_id, 'Qm.profileID')
-        self.assertEqual(ds.path, '/ipfs/Qm.path')
+        self.assertEqual(ds.profile_id, 'QmProfileID')
+        self.assertEqual(ds.path, '/ipfs/QmPath')
         self.assertFalse(ds._is_populated)
 
     def test_init_from_get(self):
         loader.set_instance(mock_loader.DatasetMockLoader())
         ds = dataset.Dataset(GET_OBJ)
-        self.assertEqual(ds.username, 'me')
+        self.assertEqual(ds.username, 'peer')
         self.assertEqual(ds.name, 'first_dataset')
-        self.assertEqual(ds.path, '/ipfs/Qm.path')
+        self.assertEqual(ds.path, '/ipfs/QmPath')
 
-        self.assertEqual(ds.body_path_value, "/ipfs/Qm.bodyPath")
-        self.assertEqual(ds.previous_path_value, "/ipfs/Qm.previousPath")
+        self.assertEqual(ds.body_path_value, "/ipfs/QmBodyPath")
+        self.assertEqual(ds.previous_path_value, "/ipfs/QmPreviousPath")
 
         # Checking a subset of the possible fields for brevity
 
-        # TODO - should I test every field? I realized it would get pretty verbose but I can.
-        # I figured I'd test set_fields and move on.
-        # However if you want a super verbose and thorough comparison I can do that.
         self.assertIsInstance(ds.commit_component, dataset.Commit)
-        self.assertEqual(ds.commit_component.author, {"id": "Qm.commit.author.id"})
+        self.assertEqual(ds.commit_component.author, {"id": "QmCommitAuthorId"})
         self.assertEqual(ds.commit_component.message, "commit.message")
         self.assertEqual(ds.commit_component.timestamp, "2020-01-02T03:04:05.124963898Z")
 
@@ -110,7 +107,7 @@ class DatasetTests(unittest.TestCase):
 
     def test_populate(self):
         loader.set_instance(mock_loader.DatasetMockLoader(get_responses={
-            'me/first_dataset': GET_OBJ
+            'peer/first_dataset': GET_OBJ
         }))
         ds = dataset.Dataset(LIST_OBJ)
         self.assertFalse(ds._is_populated)
@@ -129,7 +126,7 @@ class DatasetTests(unittest.TestCase):
 
     def test_body(self):
         loader.set_instance(mock_loader.DatasetMockLoader(get_body_responses={
-            'me/first_dataset': 'dataframe standin'
+            'peer/first_dataset': 'dataframe standin'
         }))
         ds = dataset.Dataset(GET_OBJ)
         self.assertIsNone(ds.body_component)

--- a/tests/mock_loader.py
+++ b/tests/mock_loader.py
@@ -48,3 +48,25 @@ class MockLoader(object):
             raise RuntimeError('dataset ref not found: "{}"'.format(ref))
         return MOCK_DATASET_LIST[index]
 
+class DatasetMockLoader(object): # TODO - better name and place
+    def __init__(self, list_response=None, get_responses=None, get_body_responses=None):
+        self.list_response = list_response
+        self.get_responses = get_responses or {}
+        self.get_body_responses = get_body_responses or {}
+
+    def list_dataset_objects(self, username=None):
+        if self.list_response is None:
+            raise RuntimeError('Got unexpected call to list_dataset_objects')
+        return self.list_response
+
+    def get_dataset_object(self, ref):
+        try:
+            return self.get_responses[ref.human()]
+        except KeyError:
+            raise RuntimeError('Got unexpected call to get_dataset_object')
+
+    def load_body(self, ref, structure):
+        try:
+            return self.get_body_responses[ref.human()]
+        except KeyError:
+            raise RuntimeError('Got unexpected call to load_body')

--- a/tests/util_test.py
+++ b/tests/util_test.py
@@ -12,6 +12,15 @@ class UtilTests(unittest.TestCase):
         self.assertEqual(util.to_snake_case('SomeNameLotsOfCaps'),
                          'some_name_lots_of_caps')
 
+    def test_set_fields(self):
+        class Component(object):
+            pass
+        component = Component()
+        util.set_fields(component, {'a': 1, 'b': 2}, ['b', 'c'])
+        self.assertFalse(hasattr(component, 'a'))
+        self.assertEqual(component.b, 2)
+        self.assertIsNone(component.c)
+
 
 if __name__ == '__main__':
   unittest.main()


### PR DESCRIPTION
My goal here is to deal with the fact that `Dataset` items returned from `qri.list()` doesn't have all of the fields (notably including `body`) that do `Dataset` items returned from `qri.get(...)`. The fundamental problem is that `qri list` just gives different data than `qri get...` (and not a strict subset, either; it has the `versionInfo` stuff). I have two approaches in two different PRs. This is one of them. (the other is #22)

For this approach, I split the stuff gotten via `qri get...` and `qri list` into two classes `FromGetData` and `FromListData`. A `Dataset` now contains one of each. A `Dataset` can be initialized from either data obtained with `qri list` or `qri get...`, and fills in the appropriate one of these two. When a field of `Dataset` is called that requires data from the other, it calls `qri get ...` or `qri list` as appropriate and auto-populates it.