### PR TITLE
fix: Add `requests` library as requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,8 @@ setuptools.setup(
     packages=setuptools.find_packages(),
     install_requires=[
         'pandas==1.0.0',
-        'Markdown==3.2.2'
+        'Markdown==3.2.2',
+        'requests==2.24.0',
     ],
     classifiers=[
         'Programming Language :: Python',


### PR DESCRIPTION
I noticed `requests` was expected and missing from my virtualenv when I updated master. I'm guessing we should do this?