### PR TITLE
Added array dtype in loader.py

### DIFF
--- a/qri/loader.py
+++ b/qri/loader.py
@@ -126,4 +126,6 @@ def pd_type(t):
         return 'string'
     elif t == 'bool':
         return 'bool'
+    elif t == 'array':
+        return 'array'
     raise RuntimeError('Unknown type: "%s"' % t)


### PR DESCRIPTION
I was trying `qri.get('xristosk/bandcamp_artists').body` but I received `RuntimeError: Unknown type: "array"`.

Traceback:
```
---------------------------------------------------------------------------
RuntimeError                              Traceback (most recent call last)
<ipython-input-2-221d49128db4> in <module>
----> 1 df = qri.get('xristosk/bandcamp_artists').body
      2 df.head()

~/datasets/notebooks/qri/dataset.py in body(self)
    115         if self.body_component is None:
    116             ref = dsref.Ref(self.username, self.name)
--> 117             df = loader.instance().load_body(ref, self.structure)
    118             self.body_component = df
    119         return self.body_component

~/datasets/notebooks/qri/loader.py in load_body(self, ref, structure)
     66         columns = [e for e in structure.schema['items']['items']]
     67         col_names = [c['title'] for c in columns]
---> 68         types = {c['title']: pd_type(c['type']) for c in columns}
     69         header = 0 if structure.format_config.get('headerRow') else None
     70         df = None

~/datasets/notebooks/qri/loader.py in <dictcomp>(.0)
     66         columns = [e for e in structure.schema['items']['items']]
     67         col_names = [c['title'] for c in columns]
---> 68         types = {c['title']: pd_type(c['type']) for c in columns}
     69         header = 0 if structure.format_config.get('headerRow') else None
     70         df = None

~/datasets/notebooks/qri/loader.py in pd_type(t)
    127     elif t == 'bool':
    128         return 'bool'
--> 129     raise RuntimeError('Unknown type: "%s"' % t)

RuntimeError: Unknown type: "array"
```
As a possible fix, I added array as a dtype in the `pd_type` function. It worked fine for this case.